### PR TITLE
Call `onBlur` only when selector is open

### DIFF
--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -395,7 +395,7 @@ module.exports = create-class do
                 return false if (typeof element == \undefined) or element == null
                 return true if element == root-node
                 dom-node-contains element.parent-element
-            if !(dom-node-contains target)
+            if !(dom-node-contains target) and @props.open
                 @props.on-open-change false
                 @props.on-blur @props.values, \click
         document.add-event-listener \click, @external-click-listener, true


### PR DESCRIPTION
Currently we're calling onBlur for every click on a page even when the selector isn't open. This can be bad for cases where we track whether a user closed a selector without choosing anything. 

I tried running the tests and add my own but I'm getting an error on `npm install` See below. 

```
14 errors generated.
make: *** [Release/obj.target/contextify/src/contextify.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/alurim/.nvm/versions/node/v4.2.1/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:270:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Darwin 15.0.0
gyp ERR! command "/Users/alurim/.nvm/versions/node/v4.2.1/bin/node" "/Users/alurim/.nvm/versions/node/v4.2.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/alurim/Code/react-selectize/node_modules/jsdom/node_modules/contextify
gyp ERR! node -v v4.2.1
gyp ERR! node-gyp -v v3.0.3
gyp ERR! not ok
npm ERR! Darwin 15.0.0
npm ERR! argv "/Users/alurim/.nvm/versions/node/v4.2.1/bin/node" "/Users/alurim/.nvm/versions/node/v4.2.1/bin/npm" "install"
npm ERR! node v4.2.1
npm ERR! npm  v2.14.7
npm ERR! code ELIFECYCLE

npm ERR! contextify@0.1.14 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the contextify@0.1.14 install script 'node-gyp rebuild'.
npm ERR! This is most likely a problem with the contextify package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls contextify
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/alurim/Code/react-selectize/npm-debug.log
```