### PR TITLE
added a new prop to disable the embedded input element of a SimpleSelect

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,6 +10,7 @@
 |    defaultValue            | Item                                | similar to the defaultValue prop of React.DOM.Select |
 |    delimiters              | [KeyCode]                           | a collection of character keycodes that when pressed confirm selection of the highlighted item |
 |    disabled                | Boolean                             | disables interaction with the Select control|
+|    disabledTextInput       | Boolean                             | only disables the embedded text input element|
 |    dropdownDirection       | Int                                 | defaults to 1, setting it to -1 opens the dropdown upward|
 |    editable                | Boolean                             | defaults to false, setting it to true makes the selected option editable|
 |    filterOptions           | [Item]-> String -> [Item]           | implement this function for custom synchronous filtering logic, `(options, search) {return options}`|

--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -50,6 +50,7 @@ module.exports = create-class do
         # render-no-results-found :: () -> ReactElement
         # render-group-title :: Int -> Group -> ReactElement
         # render-option :: Int -> Item -> ReactElement
+        disabledTextInput: false
 
         # render-value :: Int -> Item -> ReactElement
         render-value: ({label}) ->
@@ -139,7 +140,7 @@ module.exports = create-class do
                     
                     # SEARCH INPUT BOX
                     ResizableInput do
-                        disabled: @props.disabled
+                        disabled: @props.disabled || @props.disabledTextInput
                         ref: \search
                         type: \text
                         value: @props.search

--- a/src/SimpleSelect.ls
+++ b/src/SimpleSelect.ls
@@ -45,6 +45,7 @@ module.exports = React.create-class do
         # theme :: String
         uid: id # uid :: (Equatable e) => Item -> e
         # value :: Item
+        # disabledTextInput :: Boolean
 
     # render :: () -> ReactElement
     render: -> 
@@ -58,7 +59,7 @@ module.exports = React.create-class do
         {
             autofocus, autosize, delimiters, disabled, dropdown-direction, group-id, groups, groups-as-columns, 
             name, render-group-title, serialize, tether, theme, transition-enter, transition-leave, 
-            transition-enter-timeout, transition-leave-timeout, uid
+            transition-enter-timeout, transition-leave-timeout, uid, disabledTextInput
         }? = @props
             
         # if the user hits the return key on an empty dropdown, then hide the dropdown and clear the search text
@@ -84,6 +85,7 @@ module.exports = React.create-class do
             transition-enter-timeout
             transition-leave
             transition-leave-timeout
+            disabledTextInput
 
             ref: \select
 


### PR DESCRIPTION
By disabling the input element within a simple select, it is possible to use react-selectize for select elements where at least one value has to be selected.

Sometimes it is simply not desired, that the user can input text.