### PR TITLE
added a new prop to hide the reset button of a SimpleSelect

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,6 +10,7 @@
 |    defaultValue            | Item                                | similar to the defaultValue prop of React.DOM.Select |
 |    delimiters              | [KeyCode]                           | a collection of character keycodes that when pressed confirm selection of the highlighted item |
 |    disabled                | Boolean                             | disables interaction with the Select control|
+|    hideResetButton         | Boolean                             | hides the reset button, even if the select element is not empty |
 |    dropdownDirection       | Int                                 | defaults to 1, setting it to -1 opens the dropdown upward|
 |    editable                | Boolean                             | defaults to false, setting it to true makes the selected option editable|
 |    filterOptions           | [Item]-> String -> [Item]           | implement this function for custom synchronous filtering logic, `(options, search) {return options}`|

--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -50,6 +50,7 @@ module.exports = create-class do
         # render-no-results-found :: () -> ReactElement
         # render-group-title :: Int -> Group -> ReactElement
         # render-option :: Int -> Item -> ReactElement
+        hideResetButton: false
 
         # render-value :: Int -> Item -> ReactElement
         render-value: ({label}) ->
@@ -185,7 +186,7 @@ module.exports = create-class do
                     # LIST OF SELECTED VALUES (AFTER THE ANCHOR)
                     render-selected-values [anchor-index + 1 til @props.values.length]
                      
-                if @props.values.length > 0
+                if @props.values.length > 0 && !@props.hideResetButton
 
                     div do 
                         class-name: \react-selectize-reset-container

--- a/src/SimpleSelect.ls
+++ b/src/SimpleSelect.ls
@@ -45,6 +45,7 @@ module.exports = React.create-class do
         # theme :: String
         uid: id # uid :: (Equatable e) => Item -> e
         # value :: Item
+        # hideResetButton :: Boolean
 
     # render :: () -> ReactElement
     render: -> 
@@ -58,7 +59,7 @@ module.exports = React.create-class do
         {
             autofocus, autosize, delimiters, disabled, dropdown-direction, group-id, groups, groups-as-columns, 
             name, render-group-title, serialize, tether, theme, transition-enter, transition-leave, 
-            transition-enter-timeout, transition-leave-timeout, uid
+            transition-enter-timeout, transition-leave-timeout, uid, hideResetButton
         }? = @props
             
         # if the user hits the return key on an empty dropdown, then hide the dropdown and clear the search text
@@ -84,6 +85,7 @@ module.exports = React.create-class do
             transition-enter-timeout
             transition-leave
             transition-leave-timeout
+            hideResetButton
 
             ref: \select
 


### PR DESCRIPTION
This is a nice to have in order to create a select element, that has at least one value selected (see https://github.com/furqanZafar/react-selectize/pull/40).

This can also be done with css, but I think it's preferable to do it in react.