### PR TITLE
Fix synthetic event warning on React v15

### DIFF
--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -268,6 +268,7 @@ module.exports = create-class do
 
     # handle-keydown :: ComputedState -> Event -> Boolean
     handle-keydown: ({anchor-index}, e) ->
+        e.persist()
 
         # always handle the tab, backspace & escape keys
         switch e.which


### PR DESCRIPTION
When input some characters to `SimpleSelect`, React v15.0.2 gives following warning:

> Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the method `which` on a released/nullified synthetic event. This is a no-op function. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.

This PR fixes that.