### PR TITLE
Correct peer deps list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ the `uid` function is used internally for performance optimization.
 ## Peer Deps
 * react
 * react-dom
-* react-addons-css-transition
+* react-addons-css-transition-group
 * react-addons-shallow-compare
 
 ## Development


### PR DESCRIPTION
`react-addons-css-transition` was listed in the README instead of the correct `react-addons-css-transition-group`.

Awesome project :+1:.