### PR TITLE
wrap ResizableInput with .input-wrapper in order to use .input-wrapper::before pseudo selectors

### DIFF
--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -158,49 +158,51 @@ module.exports = create-class do
                     render-selected-values [0 to anchor-index]
                     
                     # SEARCH INPUT BOX
-                    ResizableInput do
-                        {disabled: @props.disabled} <<< @props.input-props <<< {
-                            ref: \search
-                            type: \text
-                            value: @props.search
+                    div do
+                        class-name: \input-wrapper
+                        ResizableInput do
+                            {disabled: @props.disabled} <<< @props.input-props <<< {
+                                ref: \search
+                                type: \text
+                                value: @props.search
 
-                            # update the search text & highlight the first option
-                            on-change: ({current-target:{value}}) ~>
-                                @props.on-search-change value, ~>
-                                    @highlight-and-scroll-to-selectable-option do
-                                        @props.first-option-index-to-highlight @props.options
-                                        1
+                                # update the search text & highlight the first option
+                                on-change: ({current-target:{value}}) ~>
+                                    @props.on-search-change value, ~>
+                                        @highlight-and-scroll-to-selectable-option do
+                                            @props.first-option-index-to-highlight @props.options
+                                            1
 
-                            # show the list of options (noop if caused by invocation of @focus-on-input function)
-                            on-focus: (e) !~>
-                                # @focus-lock propery is set to true by invoking the @focus-on-input! method
-                                # if @focus-lock is false, it implies this focus event was fired as a result of an external action
-                                <~ do ~> (callback) ~> 
-                                    if !!@focus-lock 
-                                        callback @focus-lock = false 
-                                    
-                                    else 
-                                        <~ @on-open-change true
-                                        callback true
+                                # show the list of options (noop if caused by invocation of @focus-on-input function)
+                                on-focus: (e) !~>
+                                    # @focus-lock propery is set to true by invoking the @focus-on-input! method
+                                    # if @focus-lock is false, it implies this focus event was fired as a result of an external action
+                                    <~ do ~> (callback) ~> 
+                                        if !!@focus-lock 
+                                            callback @focus-lock = false 
+                                        
+                                        else 
+                                            <~ @on-open-change true
+                                            callback true
 
-                                # invokes on-focus listener with the reason depending on the value of @focus-lock
-                                @props.on-focus e
+                                    # invokes on-focus listener with the reason depending on the value of @focus-lock
+                                    @props.on-focus e
 
-                            on-blur: (e) ~>
-                                # to prevent closing the dropdown when the user tries to click & drag the scrollbar in IE
-                                return if @refs.dropdown-menu and document.active-element == (find-DOM-node @refs.dropdown-menu)
+                                on-blur: (e) ~>
+                                    # to prevent closing the dropdown when the user tries to click & drag the scrollbar in IE
+                                    return if @refs.dropdown-menu and document.active-element == (find-DOM-node @refs.dropdown-menu)
 
-                                <~ @close-dropdown
+                                    <~ @close-dropdown
 
-                                # fire on-blur event listener
-                                @props.on-blur e
+                                    # fire on-blur event listener
+                                    @props.on-blur e
 
-                            # on-paste :: Event -> Boolean
-                            on-paste: @props.on-paste
+                                # on-paste :: Event -> Boolean
+                                on-paste: @props.on-paste
 
-                            # on-key-down :: Event -> Boolean
-                            on-key-down: (e) ~> @handle-keydown {anchor-index}, e
-                        }
+                                # on-key-down :: Event -> Boolean
+                                on-key-down: (e) ~> @handle-keydown {anchor-index}, e
+                            }
 
                     # LIST OF SELECTED VALUES (AFTER THE ANCHOR)
                     render-selected-values [anchor-index + 1 til @props.values.length]

--- a/themes/base.styl
+++ b/themes/base.styl
@@ -36,6 +36,10 @@ height = 30px
             flex-grow 1
             flex-wrap wrap
 
+            .input-wrapper
+                margin: 0px
+                padding: 0px
+
             .resizable-input
                 background none
                 border none


### PR DESCRIPTION
This is because `<input>` is a replaced element which doesn't `::before` and `::after` available.

FYI: See https://github.com/furqanZafar/react-selectize/pull/116/files?w=1 to review my code.
