### PR TITLE
Prevent gulp from generating invalid 'display: box' rules

### DIFF
--- a/themes/index.styl
+++ b/themes/index.styl
@@ -1,3 +1,6 @@
+flex-version = flex
+vendor-prefixes = official
+
 @require 'default'
 @require 'bootstrap3'
 @require 'material'


### PR DESCRIPTION
I was having the same issue that was mentioned in https://github.com/furqanZafar/react-selectize/issues/121 and traced the problem to the same issue that was happening here https://github.com/tj/nib/issues/312. Adding the fix suggested in that bug allowed for generating css that will no longer through an error when using webpack's postcss/autoprefixer.