### PR TITLE
Add support for React v15.5 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ the `uid` function is used internally for performance optimization.
 * [tether](https://github.com/HubSpot/tether)
 
 ## Peer Deps
+* create-react-class
 * react
 * react-dom
-* react-addons-css-transition-group
-* react-addons-shallow-compare
+* react-transition-group
 
 ## Development
 * `npm install`

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   ],
   "description": "A Stateless & Flexible Select component for React inspired by Selectize",
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "bower-prelude-ls": "*",
     "prelude-extension": "https://npmcdn.com/prelude-extension@0.0.13/bower.zip",
     "tether": "~1.1.1"

--- a/gulpfile.ls
+++ b/gulpfile.ls
@@ -104,8 +104,7 @@ create-standalone-build = (minify, {file, directory}) ->
         .exclude \prelude-extension
         .exclude \react
         .exclude \react-dom
-        .exclude \react-addons-css-transition-group
-        .exclude \react-addons-shallow-compare
+        .exclude \react-transition-group
         .exclude \tether
         .transform browserify-shim
         .bundle!

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "tether": "^1.1.1"
   },
   "peerDependencies": {
+    "create-react-class": "^15.0.0",
     "react": "^0.14.0 || ^15.0.0",
     "react-addons-css-transition-group": "^0.14.0 || ^15.0.0",
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "browserify-shim": {
+    "create-react-class": "global:createReactClass",
     "prelude-extension": "global:preludeExtension",
     "react": "global:React",
     "react-addons-css-transition-group": "global:React.addons.CSSTransitionGroup",
@@ -35,6 +37,7 @@
     "browserify": "^9.0.3",
     "browserify-shim": "^3.8.10",
     "coveralls": "^2.11.4",
+    "create-react-class": "^15.0.0",
     "gulp": "^3.8.11",
     "gulp-connect": "^2.2.0",
     "gulp-if": "^1.2.5",
@@ -44,7 +47,6 @@
     "gulp-stylus": "^2.0.1",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "history": "^1.11.0",
     "istanbul": "^0.3.20",
     "jquery-browserify": "^1.8.1",
     "jsdom": "^3.1.2",
@@ -58,7 +60,7 @@
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-addons-test-utils": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
-    "react-router": "^1.0.0-rc1",
+    "react-router": "3.0.5",
     "react-tools": "^0.13.3",
     "run-sequence": "^1.1.5",
     "should": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -17,16 +17,14 @@
   "peerDependencies": {
     "create-react-class": "^15.0.0",
     "react": "^0.14.0 || ^15.0.0",
-    "react-addons-css-transition-group": "^0.14.0 || ^15.0.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
+    "react-transition-group": "^1.1.2",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "browserify-shim": {
     "create-react-class": "global:createReactClass",
     "prelude-extension": "global:preludeExtension",
     "react": "global:React",
-    "react-addons-css-transition-group": "global:React.addons.CSSTransitionGroup",
-    "react-addons-shallow-compare": "global:React.addons.shallowCompare",
+    "react-transition-group": "global:ReactTransitionGroup",
     "react-dom": "global:ReactDOM",
     "tether": "global:Tether"
   },
@@ -56,9 +54,7 @@
     "mocha-lcov-reporter": "^1.0.0",
     "nib": "^1.1.0",
     "react": "^0.14.0 || ^15.0.0",
-    "react-addons-css-transition-group": "^0.14.0 || ^15.0.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
-    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
+    "react-transition-group": "^1.1.2",
     "react-dom": "^0.14.0 || ^15.0.0",
     "react-router": "3.0.5",
     "react-tools": "^0.13.3",

--- a/public/components/AceEditor.ls
+++ b/public/components/AceEditor.ls
@@ -7,9 +7,9 @@ require \brace/mode/livescript
 require \brace/theme/chrome
 {each} = require \prelude-ls
 {DOM:{div}}:React = require \react
+create-react-class = require \create-react-class
 
-
-module.exports = React.create-class {
+module.exports = create-react-class {
 
     display-name: \AceEditor
 

--- a/public/components/App.ls
+++ b/public/components/App.ls
@@ -11,11 +11,12 @@ require! \react-router
 Link = create-factory react-router.Link
 Route = create-factory react-router.Route
 Router = create-factory react-router.Router
-create-history = require \history/lib/createHashHistory
+hash-history = require \react-router/lib/HashHistory
 require! \react-tools
 Example = create-factory require \./Example.ls
 {HighlightedText, SimpleSelect, MultiSelect, ReactSelectize} = require \index.ls
 _ = require \underscore
+create-react-class = require \create-react-class
 
 examples = 
     multi:
@@ -207,7 +208,7 @@ This demo shows how to integrate third-party data from cdn.js
             ls: fs.read-file-sync \public/examples/simple/RemoteOptions.ls, \utf8 
         ...
 
-App = React.create-class do
+App = create-react-class do
 
     display-name: \App
 
@@ -279,6 +280,6 @@ App = React.create-class do
 
 render do 
     Router do 
-        history: create-history query-key: false
+        history: hash-history # query-key: false
         Route path: \/, component: App
     document.get-element-by-id \mount-node

--- a/public/components/Example.ls
+++ b/public/components/Example.ls
@@ -3,8 +3,9 @@
 {find-DOM-node} = require \react-dom
 AceEditor = create-factory require \./AceEditor.ls
 {debounce} = require \underscore
+create-react-class = require \create-react-class
 
-module.exports = React.create-class do
+module.exports = create-react-class do
 
     display-name: \Example
 

--- a/public/examples/multi/Animation.jsx
+++ b/public/examples/multi/Animation.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/Animation.ls
+++ b/public/examples/multi/Animation.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/ChangeCallback.jsx
+++ b/public/examples/multi/ChangeCallback.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/ChangeCallback.ls
+++ b/public/examples/multi/ChangeCallback.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/Cursor.jsx
+++ b/public/examples/multi/Cursor.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: () -> ReactElement
     render: function(){

--- a/public/examples/multi/Cursor.ls
+++ b/public/examples/multi/Cursor.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: () -> ReactElement
     render: ->

--- a/public/examples/multi/CustomRendering.jsx
+++ b/public/examples/multi/CustomRendering.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function() {

--- a/public/examples/multi/CustomRendering.ls
+++ b/public/examples/multi/CustomRendering.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/DisableSelected.jsx
+++ b/public/examples/multi/DisableSelected.jsx
@@ -1,6 +1,6 @@
 // MultiSelect = require("react-selectize").MultiSelect
 
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/DisableSelected.ls
+++ b/public/examples/multi/DisableSelected.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/DropdownDirection.jsx
+++ b/public/examples/multi/DropdownDirection.jsx
@@ -1,18 +1,18 @@
 Form = createReactClass({
-    
+
     // render :: a -> ReactElement
     render: function(){
         options = ["apple", "mango", "grapes", "melon", "strawberry"].map(function(fruit){
             return {label: fruit, value: fruit}
         });
-        return <MultiSelect 
-            options = {options} 
-            placeholder = "Select fruits" 
+        return <MultiSelect
+            options = {options}
+            placeholder = "Select fruits"
             ref = "select"
             dropdownDirection = {this.state.dropdownDirection}
         />
     },
-    
+
     // getInitialState :: a -> UIState
     getInitialState: function(){
         return {dropdownDirection: 1}
@@ -24,7 +24,7 @@ Form = createReactClass({
         this.onScrollChange = function(){
             if (typeof self.refs.select == "undefined")
                 return;
-            var screenTop = self.refs.select.getDOMNode().offsetTop - (window.scrollY || document.documentElement.scrollTop);
+            var screenTop = findDOMNode(self.refs.select).offsetTop - (window.scrollY || document.documentElement.scrollTop);
             dropdownDirection = (window.innerHeight - screenTop) < 215 ? -1 : 1
             if (self.state.dropdownDirection != dropdownDirection)
                 self.setState({dropdownDirection: dropdownDirection});

--- a/public/examples/multi/DropdownDirection.jsx
+++ b/public/examples/multi/DropdownDirection.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/DropdownDirection.ls
+++ b/public/examples/multi/DropdownDirection.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/MaxValues.jsx
+++ b/public/examples/multi/MaxValues.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/MaxValues.ls
+++ b/public/examples/multi/MaxValues.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/MultiSelect.jsx
+++ b/public/examples/multi/MultiSelect.jsx
@@ -1,6 +1,6 @@
 // MultiSelect = require("react-selectize").MultiSelect
 
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/MultiSelect.ls
+++ b/public/examples/multi/MultiSelect.ls
@@ -1,6 +1,7 @@
 # {MultiSelect} = require \react-selectize
 
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/OptionGroups.jsx
+++ b/public/examples/multi/OptionGroups.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/OptionGroups.ls
+++ b/public/examples/multi/OptionGroups.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/Tags.jsx
+++ b/public/examples/multi/Tags.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/Tags.ls
+++ b/public/examples/multi/Tags.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/TagsBasic.jsx
+++ b/public/examples/multi/TagsBasic.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/TagsBasic.ls
+++ b/public/examples/multi/TagsBasic.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/multi/Tether.jsx
+++ b/public/examples/multi/Tether.jsx
@@ -1,6 +1,6 @@
 // MultiSelect = require("react-selectize").MultiSelect
 
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/multi/Tether.ls
+++ b/public/examples/multi/Tether.ls
@@ -1,6 +1,7 @@
 # {MultiSelect} = require \react-selectize
 
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/ChangeCallback.jsx
+++ b/public/examples/simple/ChangeCallback.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/ChangeCallback.ls
+++ b/public/examples/simple/ChangeCallback.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/Children.jsx
+++ b/public/examples/simple/Children.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/Children.ls
+++ b/public/examples/simple/Children.ls
@@ -1,6 +1,7 @@
 SimpleSelectFactory = React.create-factory SimpleSelect
 
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/CreateFromSearch.jsx
+++ b/public/examples/simple/CreateFromSearch.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/CreateFromSearch.ls
+++ b/public/examples/simple/CreateFromSearch.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/CustomRendering.jsx
+++ b/public/examples/simple/CustomRendering.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/CustomRendering.ls
+++ b/public/examples/simple/CustomRendering.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: () -> ReactElement
     render: ->

--- a/public/examples/simple/Editable.jsx
+++ b/public/examples/simple/Editable.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/Editable.ls
+++ b/public/examples/simple/Editable.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/EventListeners.jsx
+++ b/public/examples/simple/EventListeners.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/EventListeners.ls
+++ b/public/examples/simple/EventListeners.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/RemoteOptions.jsx
+++ b/public/examples/simple/RemoteOptions.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/RemoteOptions.ls
+++ b/public/examples/simple/RemoteOptions.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/RestoreOnBackspace.jsx
+++ b/public/examples/simple/RestoreOnBackspace.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/RestoreOnBackspace.ls
+++ b/public/examples/simple/RestoreOnBackspace.ls
@@ -1,4 +1,5 @@
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/SearchHighlighting.jsx
+++ b/public/examples/simple/SearchHighlighting.jsx
@@ -3,7 +3,7 @@
 // HighlightedText = ReactSelectize.HighlightedText
 // SimpleSelect = ReactSelectize.SimpleSelect
 
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/SearchHighlighting.ls
+++ b/public/examples/simple/SearchHighlighting.ls
@@ -1,7 +1,8 @@
 # {partition-string} = require \prelude-extension
 # {HighlightedText, SimpleSelect} = require \ReactSelectize
 
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/Selectability.jsx
+++ b/public/examples/simple/Selectability.jsx
@@ -1,4 +1,4 @@
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/Selectability.ls
+++ b/public/examples/simple/Selectability.ls
@@ -1,5 +1,6 @@
-Form = React.create-class do 
-    
+create-react-class = require \create-react-class
+Form = create-react-class do
+
     # render :: a -> ReactElement
     render: ->
         React.create-element SimpleSelect,

--- a/public/examples/simple/SimpleSelect.jsx
+++ b/public/examples/simple/SimpleSelect.jsx
@@ -1,6 +1,6 @@
 // SimpleSelect = require("react-selectize").SimpleSelect
 
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/SimpleSelect.ls
+++ b/public/examples/simple/SimpleSelect.ls
@@ -1,6 +1,7 @@
 # {SimpleSelect} = require \react-selectize
 
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/public/examples/simple/Themes.jsx
+++ b/public/examples/simple/Themes.jsx
@@ -1,6 +1,6 @@
 // SimpleSelect = require("react-selectize").SimpleSelect
 
-Form = React.createClass({
+Form = createReactClass({
     
     // render :: a -> ReactElement
     render: function(){

--- a/public/examples/simple/Themes.ls
+++ b/public/examples/simple/Themes.ls
@@ -1,6 +1,7 @@
 # {SimpleSelect} = require \react-selectize
 
-Form = React.create-class do 
+create-react-class = require \create-react-class
+Form = create-react-class do
     
     # render :: a -> ReactElement
     render: ->

--- a/src/DivWrapper.ls
+++ b/src/DivWrapper.ls
@@ -1,8 +1,9 @@
-{create-class, DOM:{div}} = require \react
+{DOM:{div}} = require \react
+create-react-class = require \create-react-class
 
 # used to detect when the dropdown has been added/removed from dom, 
 # so we can adjust the height of the parent element
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # get-default-props :: () -> Props
     get-default-props: ->

--- a/src/DropdownMenu.ls
+++ b/src/DropdownMenu.ls
@@ -2,7 +2,8 @@
 {filter, id, map} = require \prelude-ls
 
 {is-equal-to-object} = require \prelude-extension
-{DOM:{div, input, span}, create-class, create-factory}:React = require \react
+{DOM:{div, input, span}, create-factory}:React = require \react
+create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
 ReactCSSTransitionGroup = create-factory require \react-addons-css-transition-group
 ReactTether = create-factory require \./ReactTether
@@ -10,7 +11,7 @@ DivWrapper = create-factory require \./DivWrapper
 OptionWrapper = create-factory require \./OptionWrapper
 {cancel-event, class-name-from-object} = require \./utils
 
-module.exports = create-class do
+module.exports = create-react-class do
 
     display-name: \DropdownMenu
 

--- a/src/DropdownMenu.ls
+++ b/src/DropdownMenu.ls
@@ -5,7 +5,7 @@
 {DOM:{div, input, span}, create-factory}:React = require \react
 create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
-ReactCSSTransitionGroup = create-factory require \react-addons-css-transition-group
+ReactCSSTransitionGroup = create-factory require \react-transition-group/CSSTransitionGroup
 ReactTether = create-factory require \./ReactTether
 DivWrapper = create-factory require \./DivWrapper
 OptionWrapper = create-factory require \./OptionWrapper
@@ -94,7 +94,7 @@ module.exports = create-react-class do
                 transition-enter-timeout: @props.transition-enter-timeout
                 transition-leave-timeout: @props.transition-leave-timeout
                 class-name: "dropdown-menu-wrapper #{dynamic-class-name}"
-                ref: \dropdownMenuWrapper
+                ref: (element) -> @dropdown-menu-wrapper = element
                 @render-dropdown computed-state
 
         else
@@ -141,12 +141,12 @@ module.exports = create-react-class do
             # DROPDOWN
             DivWrapper do 
                 class-name: "dropdown-menu #{dynamic-class-name}"
-                ref: \dropdownMenu
+                ref: (element) -> !!element && @dropdown-menu = element
 
                 # on-height-change :: Number -> ()
                 on-height-change: (height) !~> 
-                    if @refs.dropdown-menu-wrapper
-                        find-DOM-node @refs.dropdown-menu-wrapper .style.height = "#{height}px"
+                    if @dropdown-menu-wrapper
+                        find-DOM-node @dropdown-menu-wrapper .style.height = "#{height}px"
 
                 # NO RESULT FOUND   
                 if @props.options.length == 0
@@ -185,7 +185,7 @@ module.exports = create-react-class do
 
     # component-did-update :: () -> ()
     component-did-update: !->
-        dropdown-menu = find-DOM-node @refs.dropdown-menu-wrapper ? @refs.dropdown-menu
+        dropdown-menu = find-DOM-node @dropdown-menu-wrapper ? @dropdown-menu
             ..?style.bottom = switch 
                 | @props.dropdown-direction == -1 => 
                     "#{@props.bottom-anchor!.offset-height + dropdown-menu.style.margin-bottom}px"
@@ -202,7 +202,7 @@ module.exports = create-react-class do
         option-element? = find-DOM-node @refs?["option-#{@uid-to-string uid}"]
 
         if !!option-element
-            parent-element = find-DOM-node @refs.dropdown-menu
+            parent-element = option-element.parent-element
             option-height = option-element.offset-height - 1
 
             # in other words, if the option element is below the visible region

--- a/src/HighlightedText.ls
+++ b/src/HighlightedText.ls
@@ -1,7 +1,8 @@
-{create-class, DOM:{div, span}}:React = require \react
+{DOM:{div, span}}:React = require \react
+create-react-class = require \create-react-class
 {map} = require \prelude-ls
 
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # get-default-props :: a -> Props
     get-default-props: ->

--- a/src/MultiSelect.ls
+++ b/src/MultiSelect.ls
@@ -2,10 +2,11 @@
 last, map, reject} = require \prelude-ls
 {is-equal-to-object} = require \prelude-extension
 {create-factory, DOM:{div, img, span}}:React = require \react
+create-react-class = require \create-react-class
 ReactSelectize = create-factory require \./ReactSelectize 
 {cancel-event} = require \./utils
 
-module.exports = React.create-class do
+module.exports = create-react-class do
 
     display-name: \MultiSelect
 

--- a/src/OptionWrapper.ls
+++ b/src/OptionWrapper.ls
@@ -1,9 +1,10 @@
-{create-class, DOM:{div}} = require \react
+{DOM:{div}} = require \react
+create-react-class = require \create-react-class
 {is-equal-to-object} = require \prelude-extension
 {cancel-event} = require \./utils
 
 # OptionWrapper & ValueWrapper are used for optimizing performance 
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # get-default-porps :: () -> Props
     get-default-props: ->

--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -6,7 +6,6 @@ partition, reject, reverse, Str, sort-by, sum, values} = require \prelude-ls
 {DOM:{div, input, path, span, svg}, create-factory}:React = require \react
 create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
-ReactCSSTransitionGroup = create-factory require \react-addons-css-transition-group
 ToggleButton = create-factory require \./ToggleButton
 DropdownMenu = create-factory require \./DropdownMenu
 OptionWrapper = create-factory require \./OptionWrapper

--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -3,7 +3,8 @@
 partition, reject, reverse, Str, sort-by, sum, values} = require \prelude-ls
 
 {clamp, is-equal-to-object} = require \prelude-extension
-{DOM:{div, input, path, span, svg}, create-class, create-factory}:React = require \react
+{DOM:{div, input, path, span, svg}, create-factory}:React = require \react
+create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
 ReactCSSTransitionGroup = create-factory require \react-addons-css-transition-group
 ToggleButton = create-factory require \./ToggleButton
@@ -14,7 +15,7 @@ ResetButton = create-factory require \./ResetButton
 ResizableInput = create-factory require \./ResizableInput
 {cancel-event, class-name-from-object} = require \./utils
 
-module.exports = create-class do
+module.exports = create-react-class do
 
     display-name: \ReactSelectize
 

--- a/src/ReactTether.ls
+++ b/src/ReactTether.ls
@@ -1,12 +1,12 @@
-create-react-class = require \create-react-class
+React = require \react
 {render, unmount-component-at-node} = require \react-dom
-shallow-compare = require \react-addons-shallow-compare
 Tether = require \tether
 
-module.exports = create-react-class do
+class ReactTether extends React.PureComponent
+    ->
 
     # get-default-props :: () -> Props
-    get-default-props: ->
+    @default-props =
         # target :: () -> DOMElement (invoked on component-did-mount)
         # options :: object (passed to Tether instance)
         # parent-element :: () -> DOMElement
@@ -60,8 +60,7 @@ module.exports = create-react-class do
             } <<< new-props.options
             render new-props.children, @node, ~> @tether.position!
 
-    # should-component-update :: Props -> UIState -> Boolean
-    should-component-update: (next-props, next-state) -> shallow-compare @, next-props, next-state
-
     # component-will-unmount :: () -> Void
     component-will-unmount: !-> @destroy-tether!
+
+module.exports = ReactTether

--- a/src/ReactTether.ls
+++ b/src/ReactTether.ls
@@ -1,9 +1,9 @@
-{create-class} = require \react
+create-react-class = require \create-react-class
 {render, unmount-component-at-node} = require \react-dom
 shallow-compare = require \react-addons-shallow-compare
 Tether = require \tether
 
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # get-default-props :: () -> Props
     get-default-props: ->

--- a/src/ResetButton.ls
+++ b/src/ResetButton.ls
@@ -1,7 +1,8 @@
-{create-class, create-factory, DOM:{path}} = require \react
+{create-factory, DOM:{path}} = require \react
+create-react-class = require \create-react-class
 SvgWrapper = create-factory require \./SvgWrapper
 
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # render :: a -> ReactElement
     render: ->

--- a/src/ResizableInput.ls
+++ b/src/ResizableInput.ls
@@ -1,8 +1,9 @@
 {each, obj-to-pairs} = require \prelude-ls
-{DOM:{input}, create-class, create-factory}:React = require \react
+{DOM:{input}, create-factory}:React = require \react
+create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
 
-module.exports = create-class do
+module.exports = create-react-class do
 
     display-name: \ResizableInput
 

--- a/src/SimpleSelect.ls
+++ b/src/SimpleSelect.ls
@@ -1,10 +1,11 @@
 {all, any, drop, camelize, difference, filter, find, find-index, id, last, map, reject} = require \prelude-ls
 {is-equal-to-object} = require \prelude-extension
 {create-factory, DOM:{div, img, span}}:React = require \react
+create-react-class = require \create-react-class
 ReactSelectize = create-factory require \./ReactSelectize
 {cancel-event} = require \./utils
 
-module.exports = React.create-class do
+module.exports = create-react-class do
 
     display-name: \SimpleSelect
 

--- a/src/SvgWrapper.ls
+++ b/src/SvgWrapper.ls
@@ -1,8 +1,9 @@
-{create-class, DOM:{svg}} = require \react
+{DOM:{svg}} = require \react
+create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
 
 # set the focusable attribute to false, this prevents having to press the tab key multiple times in IE
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # render :: () -> ReactElement
     render: -> svg @props

--- a/src/ToggleButton.ls
+++ b/src/ToggleButton.ls
@@ -1,7 +1,8 @@
-{create-class, create-factory, DOM:{path}} = require \react
+{create-factory, DOM:{path}} = require \react
+create-react-class = require \create-react-class
 SvgWrapper = create-factory require \./SvgWrapper
 
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # get-default-props :: () -> Props
     get-default-props: ->

--- a/src/ValueWrapper.ls
+++ b/src/ValueWrapper.ls
@@ -1,7 +1,8 @@
-{create-class, DOM:{div}} = require \react
+{DOM:{div}} = require \react
+create-react-class = require \create-react-class
 {is-equal-to-object} = require \prelude-extension
 
-module.exports = create-class do 
+module.exports = create-react-class do
 
     # get-default-porps :: () -> Props
     get-default-props: ->

--- a/test/common-tests.ls
+++ b/test/common-tests.ls
@@ -3,7 +3,7 @@ require! \assert
 {is-equal-to-object} = require \prelude-extension
 
 # React
-{create-class, create-element, DOM:{div, input, option, span}} = require \react
+{create-element, DOM:{div, input, option, span}} = require \react
 {find-DOM-node, render, unmount-component-at-node} = require \react-dom
 
 # TestUtils

--- a/test/common-tests.ls
+++ b/test/common-tests.ls
@@ -14,7 +14,7 @@ require! \assert
     scry-rendered-DOM-components-with-tag
     key-down
     Simulate:{blur, change, click, focus, key-down, mouse-down, mouse-over, mouse-out, mouse-move}
-}:TestUtils = require \react-addons-test-utils
+}:TestUtils = require \react-dom/test-utils
 
 # utils
 {create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, 

--- a/test/highlighted-text.ls
+++ b/test/highlighted-text.ls
@@ -3,7 +3,7 @@ require! \../src/HighlightedText
 {partition-string} = require \prelude-extension
 
 # React
-{create-class, create-element, DOM:{div, option, span}} = require \react
+{create-element, DOM:{div, option, span}} = require \react
 {find-DOM-node} = require \react-dom
 
 # TestUtils

--- a/test/highlighted-text.ls
+++ b/test/highlighted-text.ls
@@ -8,7 +8,7 @@ require! \../src/HighlightedText
 
 # TestUtils
 {find-rendered-DOM-component-with-class, scry-rendered-DOM-components-with-class, 
-find-rendered-DOM-component-with-tag, Simulate:{change, click, focus, key-down}}:TestUtils = require \react-addons-test-utils
+find-rendered-DOM-component-with-tag, Simulate:{change, click, focus, key-down}}:TestUtils = require \react-dom/test-utils
 
 create-highlighted-text = (props = {}) ->
     TestUtils.render-into-document do 

--- a/test/multi-select.ls
+++ b/test/multi-select.ls
@@ -4,7 +4,7 @@ require! \./common-tests
 ReactSelectize = require \../src/index.ls
 
 # React
-{create-class, create-element, DOM:{div, option, span}} = require \react
+{create-element, DOM:{div, option, span}} = require \react
 {find-DOM-node} = require \react-dom
 
 # TestUtils

--- a/test/multi-select.ls
+++ b/test/multi-select.ls
@@ -13,7 +13,7 @@ ReactSelectize = require \../src/index.ls
     scry-rendered-DOM-components-with-class, 
     find-rendered-DOM-component-with-tag
     Simulate:{change, click, focus, key-down, paste}
-}:TestUtils = require \react-addons-test-utils
+}:TestUtils = require \react-dom/test-utils
 
 # utils
 {create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, 

--- a/test/simple-select.ls
+++ b/test/simple-select.ls
@@ -4,7 +4,8 @@ require! \./common-tests
 ReactSelectize = require \../src/index.ls
 
 # React
-{create-class, create-element, DOM:{div, option, span}} = require \react
+{create-element, DOM:{div, option, span}} = require \react
+create-react-class = require \create-react-class
 {find-DOM-node} = require \react-dom
 
 # TestUtils
@@ -102,7 +103,7 @@ describe "SimpleSelect", ->
         assert.equal select.value!.label, \mango
 
     specify "must be able to block default backspace action", ->
-        {refs:{select}} = TestUtils.render-into-document create-element create-class do
+        {refs:{select}} = TestUtils.render-into-document create-element create-react-class do
             render: ->
                 create-element do 
                     ReactSelectize.SimpleSelect

--- a/test/simple-select.ls
+++ b/test/simple-select.ls
@@ -15,7 +15,7 @@ create-react-class = require \create-react-class
     scry-rendered-DOM-components-with-class
     scry-rendered-DOM-components-with-tag
     Simulate:{change, click, focus}
-}:TestUtils = require \react-addons-test-utils
+}:TestUtils = require \react-dom/test-utils
 
 # utils
 {create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, find-highlighted-option, 

--- a/test/utils.ls
+++ b/test/utils.ls
@@ -6,7 +6,7 @@
     find-rendered-DOM-component-with-class
     find-rendered-DOM-component-with-tag
     Simulate:{change, click, key-down, mouse-down}
-}:TestUtils = require \react-addons-test-utils
+}:TestUtils = require \react-dom/test-utils
 
 # create-select :: Select -> Props -> Select
 export create-select = (select-class, props, children) -->


### PR DESCRIPTION
Adding support for React v15.5 by 
replacing React.create-class with create-react-class

More info:
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html
https://facebook.github.io/react/docs/react-without-es6.html

Also updated the react-router to v3 in the examples page
so it would support React v15.5 in development mode without console warnings.

This solves issue #148 