### PR TITLE
Moved "react-dom-factories" and "react-transition-group" from peerDep…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "dependencies": {
     "prelude-extension": "^0.1.0",
     "prelude-ls": "^1.1.1",
+    "react-dom-factories": "^1.0.0",
+    "react-transition-group": "^1.1.2",
     "tether": "^1.1.1"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
-    "react-transition-group": "^1.1.2",
-    "react-dom": "^15.0.0 || ^16.0.0",
-    "react-dom-factories": "^1.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "browserify-shim": {
     "prelude-extension": "global:preludeExtension",


### PR DESCRIPTION
…s to deps, because they are used to make react-selectize work in production. PeerDependencies force the user to also use the same exact versions, which is a problem with react-transition-group (v1 and v2 do exist).