### PR TITLE
Feat: New `readOnly` property in the component's API

### DIFF
--- a/src/MultiSelect.ls
+++ b/src/MultiSelect.ls
@@ -80,8 +80,8 @@ module.exports = class MultiSelect extends React.Component
         }? = @props
 
         ReactSelectize {
-
-            autofocus
+	    
+	    autofocus
             autosize
             cancel-keyboard-event-on-selection
             class-name: "multi-select #{@props.class-name}"

--- a/src/MultiSelect.ls
+++ b/src/MultiSelect.ls
@@ -80,8 +80,8 @@ module.exports = class MultiSelect extends React.Component
         }? = @props
 
         ReactSelectize {
-	    
-	    autofocus
+            
+            autofocus
             autosize
             cancel-keyboard-event-on-selection
             class-name: "multi-select #{@props.class-name}"

--- a/src/MultiSelect.ls
+++ b/src/MultiSelect.ls
@@ -74,13 +74,13 @@ module.exports = class MultiSelect extends React.Component
         # props
         {
             autofocus, autosize, cancel-keyboard-event-on-selection, delimiters, disabled, dropdown-direction, group-id, 
-            groups, groups-as-columns, hide-reset-button, input-props, name, on-keyboard-selection-failed, render-toggle-button, 
+            groups, groups-as-columns, hide-reset-button, input-props, name, on-keyboard-selection-failed, readOnly, render-toggle-button, 
             render-group-title, render-reset-button, serialize, tether, tether-props, theme, transition-enter, transition-leave, 
             transition-enter-timeout, transition-leave-timeout, uid
         }? = @props
 
         ReactSelectize {
-            
+
             autofocus
             autosize
             cancel-keyboard-event-on-selection
@@ -97,6 +97,7 @@ module.exports = class MultiSelect extends React.Component
             input-props
             name
             on-keyboard-selection-failed
+            readOnly
             render-group-title
             render-reset-button
             render-toggle-button

--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -160,6 +160,7 @@ module.exports = class ReactSelectize extends React.Component
                             ref: \search
                             type: \text
                             value: @props.search
+                            readOnly: @props.readOnly
 
                             # update the search text & highlight the first option
                             on-change: ({current-target:{value}}) ~>

--- a/src/SimpleSelect.ls
+++ b/src/SimpleSelect.ls
@@ -78,7 +78,7 @@ module.exports = class SimpleSelect extends React.Component
         # props
         {
             autofocus, autosize, cancel-keyboard-event-on-selection, delimiters, disabled, dropdown-direction, group-id, 
-            groups, groups-as-columns, hide-reset-button, name, input-props, on-blur-resets-input, render-toggle-button,
+            groups, groups-as-columns, hide-reset-button, name, input-props, on-blur-resets-input, readOnly, render-toggle-button,
             render-group-title, render-reset-button, serialize, tether, tether-props, theme, transition-enter,
             transition-leave, transition-enter-timeout, transition-leave-timeout, uid
         }? = @props
@@ -101,6 +101,7 @@ module.exports = class SimpleSelect extends React.Component
             input-props
             name
             on-blur-resets-input
+            readOnly
             render-group-title
             render-reset-button
             render-toggle-button


### PR DESCRIPTION
Using this new property, we can set the component as `readOnly`, so no custom text-input will be allowed. 