### PR TITLE
Fix tether and dropdown-direction compatibility with bootstrap

### DIFF
--- a/src/DropdownMenu.ls
+++ b/src/DropdownMenu.ls
@@ -1,4 +1,4 @@
-# prelude ls 
+# prelude ls
 {filter, id, map} = require \prelude-ls
 
 {is-equal-to-object} = require \prelude-extension
@@ -27,25 +27,25 @@ module.exports = class DropdownMenu extends React.PureComponent
         on-option-click: ((uid) !->) # (Eq e) => e -> ()
         on-scroll-lock-change: ((scroll-lock) !-> ) # Boolean -> ()
         options: [] # [Item]
-        
+
         # render-no-results-found :: () -> ReactElement
-        render-no-results-found: -> 
+        render-no-results-found: ->
             div class-name: \no-results-found, "No results found"
-        
+
         # render-group-title :: Int -> Group -> ReactElement
         render-group-title: (index, {group-id, title}?) ->
             div do
                 class-name: \simple-group-title
                 key: group-id
                 title
-        
+
         # render-option :: Int -> Item -> ReactElement
         render-option: ({label, new-option, selectable}?) ->
             is-selectable = (typeof selectable == \undefined) or selectable
-            div do 
+            div do
                 class-name: "simple-option #{if is-selectable then '' else 'not-selectable'}"
                 span null, if !!new-option then "Add #{label} ..." else label
-        
+
         scroll-lock: false
         style: {}
         tether: false
@@ -67,7 +67,7 @@ module.exports = class DropdownMenu extends React.PureComponent
             tethered: @props.tether
 
         # (TETHERED / ANIMATED / SIMPLE) DROPDOWN
-        if @props.tether 
+        if @props.tether
             ReactTether do
                 {} <<< @props.tether-props <<<
                     options:
@@ -84,10 +84,10 @@ module.exports = class DropdownMenu extends React.PureComponent
     # render-animated-dropdown :: ComputedState -> ReactElement
     render-animated-dropdown: ({dynamic-class-name}:computed-state) ->
         if !!@props.transition-enter or !!@props.transition-leave
-            ReactCSSTransitionGroup do 
+            ReactCSSTransitionGroup do
                 ref: \dropdownMenuWrapper
                 component: \div
-                transition-name: \custom 
+                transition-name: \custom
                 transition-enter: @props.transition-enter
                 transition-leave: @props.transition-leave
                 transition-enter-timeout: @props.transition-enter-timeout
@@ -104,7 +104,7 @@ module.exports = class DropdownMenu extends React.PureComponent
             option = options[index]
             uid = @props.uid option
 
-            # OPTION WRAPPER 
+            # OPTION WRAPPER
             OptionWrapper do
                 {
                     uid
@@ -113,12 +113,12 @@ module.exports = class DropdownMenu extends React.PureComponent
                     item: option
                     highlight: @props.highlighted-uid `is-equal-to-object` uid
                     selectable: option?.selectable
-                    
-                    on-mouse-move: ({current-target}) !~> 
+
+                    on-mouse-move: ({current-target}) !~>
                         if @props.scroll-lock
                             @props.on-scroll-lock-change false
-                    
-                    on-mouse-out: !~>  
+
+                    on-mouse-out: !~>
                         if !@props.scroll-lock
                             <~ @props.on-highlighted-uid-change undefined
 
@@ -127,11 +127,11 @@ module.exports = class DropdownMenu extends React.PureComponent
                     switch
                     | (typeof option?.selectable == \boolean) and !option.selectable => on-click: cancel-event
                     | _ =>
-                        on-click: !~> 
+                        on-click: !~>
                             if !@props.scroll-lock
                                 <~ @props.on-highlighted-uid-change uid
                             @props.on-option-click @props.highlighted-uid
-                        on-mouse-over: ({current-target}) !~>  
+                        on-mouse-over: ({current-target}) !~>
                             if 'ontouchstart' of window => return false
                             if !@props.scroll-lock
                                 <~ @props.on-highlighted-uid-change uid
@@ -139,32 +139,32 @@ module.exports = class DropdownMenu extends React.PureComponent
     # render-dropdown :: ComputedState -> ReactElement
     render-dropdown: ({dynamic-class-name}) ->
         if @props.open
-            
+
             # DROPDOWN
-            DivWrapper do 
-                class-name: "dropdown-menu #{dynamic-class-name}"
+            DivWrapper do
+                class-name: "rs-dropdown-menu #{dynamic-class-name}"
                 ref: (element) !~> !!element && @dropdown-menu = element
 
                 # on-height-change :: Number -> ()
-                on-height-change: (height) !~> 
+                on-height-change: (height) !~>
                     if @refs.dropdown-menu-wrapper
                         find-DOM-node @refs.dropdown-menu-wrapper .style.height = "#{height}px"
 
-                # NO RESULT FOUND   
+                # NO RESULT FOUND
                 if @props.options.length == 0
                     @props.render-no-results-found!
-                
+
                 else if @props?.groups?.length > 0
 
                     # convert [Group] to [{index: Int, group: Group, options: [Item]}]
-                    groups = [0 til @props.groups.length] |> map (index) ~>  
+                    groups = [0 til @props.groups.length] |> map (index) ~>
                         {group-id}:group = @props.groups[index]
                         options = @props.options |> filter ~> (@props.group-id it) == group-id
                         {index, group, options}
 
                     # GROUPS
                     div class-name: "groups #{if !!@props.groups-as-columns then 'as-columns' else ''}",
-                        groups 
+                        groups
                         |> filter (.options.length > 0)
                         |> map ({index, {group-id}:group, options}) ~>
 
@@ -173,7 +173,7 @@ module.exports = class DropdownMenu extends React.PureComponent
                                 @props.render-group-title index, group, options
 
                                 # OPTIONS
-                                div do 
+                                div do
                                     class-name: \options
                                     @render-options options
 
@@ -189,10 +189,10 @@ module.exports = class DropdownMenu extends React.PureComponent
     component-did-update: (prev-props) !->
         if prev-props.dropdown-direction !== @props.dropdown-direction and @props.open
             dropdown-menu = find-DOM-node @refs.dropdown-menu-wrapper ? @dropdown-menu
-                ..?.style.bottom = switch 
-                    | @props.dropdown-direction == -1 => 
+                ..?.style.bottom = switch
+                    | @props.dropdown-direction == -1 =>
                         "#{@props.bottom-anchor!.offset-height + dropdown-menu.style.margin-bottom}px"
-                        
+
                     | _ => ""
 
     # highlight-and-scroll-to-option :: Int, (() -> ())? -> ()
@@ -226,7 +226,7 @@ module.exports = class DropdownMenu extends React.PureComponent
 
     # highlight-and-scroll-to-selectable-option :: Int, Int, (Boolean -> ())? -> ()
     highlight-and-scroll-to-selectable-option: (index, direction, callback = (->)) !->
-        
+
         # end recursion if the index violates the bounds
         if index < 0 or index >= @props.options.length
             <~ @props.on-highlighted-uid-change undefined

--- a/test/common-tests.ls
+++ b/test/common-tests.ls
@@ -18,9 +18,9 @@ require! \assert
 }:TestUtils = require \react-dom/test-utils
 
 # utils
-{create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, 
-click-on-the-document, find-highlighted-option, component-with-class-must-not-exist, press-backspace, 
-press-escape, press-tab, press-return, press-up-arrow, press-down-arrow, press-left-arrow, press-right-arrow, 
+{create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control,
+click-on-the-document, find-highlighted-option, component-with-class-must-not-exist, press-backspace,
+press-escape, press-tab, press-return, press-up-arrow, press-down-arrow, press-left-arrow, press-right-arrow,
 press-command-left}:utils = require \./utils
 
 # :: ReactClass -> Void
@@ -44,17 +44,17 @@ module.exports = (select-class) !->
     specify "must default the list of options to an empty list", ->
         select = create-select options: undefined
         click-to-open-select-control select
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
 
     specify "must show the list of options on click", ->
         select = create-select!
         click-to-open-select-control select
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
 
     specify "must open options dropdown on search change", ->
         select = create-select!
         set-input-text (get-input select), \text
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
 
     specify "must filter options list on search change", ->
         select = create-select!
@@ -95,21 +95,21 @@ module.exports = (select-class) !->
         assert.equal (get-item-text find-rendered-DOM-component-with-class select, \simple-value), \apple
 
     specify "must use search from props instead of state when available", ->
-        select = create-select do 
+        select = create-select do
             search: \orange
         input = get-input select
         set-input-text input, \apple
         assert.equal input.value, \orange
 
     specify "must invoke on-search-change when the search (state) is changed", (done) ->
-        select = create-select do 
+        select = create-select do
             on-search-change: (search) ->
                 assert.equal search, \test
                 done!
         set-input-text (get-input select), \test
 
     specify "must invoke on-search-change when the search (prop) is changed", (done) ->
-        select = create-select do 
+        select = create-select do
             search: ""
             on-search-change: (search) ->
                 assert.equal search, \test
@@ -117,7 +117,7 @@ module.exports = (select-class) !->
         set-input-text (get-input select), \test
 
     specify "must restore search on pressing backspace", ->
-        select = create-select do 
+        select = create-select do
             restore-on-backspace: -> it.label.substr 0, it.label.length - 1
         click-to-open-select-control select
         click-option find-highlighted-option select
@@ -126,19 +126,19 @@ module.exports = (select-class) !->
         assert.equal (get-input select).value, \appl
 
     specify "must create new item from search", ->
-        select = create-select do 
-            create-from-search: (..., search) -> label: search, value: search 
+        select = create-select do
+            create-from-search: (..., search) -> label: search, value: search
         set-input-text (get-input select), \test
         assert.equal (get-item-text find-highlighted-option select), "Add test ..."
 
     specify "must not be interactive when disabled", ->
-        select = create-select do 
+        select = create-select do
             disabled: true
         click-to-open-select-control select
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must be able to render custom option", ->
-        select = create-select do 
+        select = create-select do
             render-option: ({label, value}) ->
                 div class-name: \custom-option,
                     span null, label
@@ -146,7 +146,7 @@ module.exports = (select-class) !->
         assert.equal (scry-rendered-DOM-components-with-class select, \custom-option).length > 0, true
 
     specify "must be able to render custom value", ->
-        select = create-select do 
+        select = create-select do
             render-value: ({label, value}) ->
                 div class-name: \custom-value,
                     span null, label
@@ -155,9 +155,9 @@ module.exports = (select-class) !->
         find-rendered-DOM-component-with-class select, \custom-value
 
     specify "must be able to create option groups", ->
-        select = create-select do 
+        select = create-select do
             groups: [{group-id: \asia, title: \Asia}, {group-id: \europe, title: \Europe}]
-            options: 
+            options:
                 * label: \Korea
                   value: \Korea
                   group-id: \asia
@@ -168,8 +168,8 @@ module.exports = (select-class) !->
         assert.equal (scry-rendered-DOM-components-with-class select, \simple-group-title).length, 2
 
     specify "unselectable options must not be selectable", ->
-        select = create-select do 
-            options: 
+        select = create-select do
+            options:
                 * label: \apple
                   value: \apple
                   selectable: false
@@ -178,7 +178,7 @@ module.exports = (select-class) !->
         component-with-class-must-not-exist select, \highlight
 
     specify "must apply custom class-name", ->
-        select = create-select do 
+        select = create-select do
             class-name: \test
         assert.equal ((find-DOM-node select).class-name.index-of \test) > -1, true
 
@@ -193,10 +193,10 @@ module.exports = (select-class) !->
         select = create-select!
         click-to-open-select-control select
         press-escape (get-input select)
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must render custom dom for 'no results found'", ->
-        select = create-select do 
+        select = create-select do
             render-no-results-found: -> div class-name: \custom-no-results-found, "no results found"
         click-to-open-select-control select
         set-input-text (get-input select), \test-case
@@ -206,7 +206,7 @@ module.exports = (select-class) !->
         select = create-select!
         click-to-open-select-control select
         input = get-input select
-        set-input-text input, \test 
+        set-input-text input, \test
         blur input
         assert.equal select.state.search, ""
 
@@ -215,7 +215,7 @@ module.exports = (select-class) !->
         focus (get-input models)
 
     specify "must call on-focus on open", (done) ->
-        models = create-select do 
+        models = create-select do
             on-focus: -> done!
         focus (get-input models)
 
@@ -226,7 +226,7 @@ module.exports = (select-class) !->
         assert.equal (scry-rendered-DOM-components-with-class select, \simple-option).length, 1
 
     specify "must use children (array) as options when props.options is undefined", ->
-        children = 
+        children =
             * option {key: \1, value: \1}, \1
             * option {key: \2, value: \2}, \2
             * option {key: \3, value: \3}, \3
@@ -245,23 +245,23 @@ module.exports = (select-class) !->
     specify "highlight-first-selectable-option must not open the select", ->
         select = create-select!
         select.highlight-first-selectable-option!
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must highlight the second option, when creating options from search & search results are non empty", ->
-        select = create-select do 
+        select = create-select do
             create-from-search: (..., search) -> label: search, value: search
         set-input-text (get-input select), \a
         assert.equal (get-item-text find-highlighted-option select), \apple
 
     specify "must highlight the first option, when creating options from search & the search results are unselectable", ->
-        select = create-select do 
+        select = create-select do
             options: <[apple mango grapes banana kiwi dates pie]> |> map ~> label: it, value: it, selectable: false
             create-from-search: (..., search) -> label: search, value: search
         set-input-text (get-input select), \app
         assert.equal (get-item-text find-highlighted-option select), "Add app ..."
 
     specify "must flip the dropdown direction when @props.dropdown-direction = -1", ->
-        select = create-select do 
+        select = create-select do
             dropdown-direction: -1
         assert.equal (find-DOM-node select .class-name .index-of \flipped) > -1, true
 
@@ -269,7 +269,7 @@ module.exports = (select-class) !->
         select = create-select!
         click-to-open-select-control select
         blur get-input select
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must deselect on clicking reset button", ->
         select = create-select!
@@ -282,29 +282,29 @@ module.exports = (select-class) !->
         select = TestUtils.render-into-document (create-element select-class, {options: null}, [])
         click-to-open-select-control select
         set-input-text (get-input select), \test
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
         find-rendered-DOM-component-with-class select, \no-results-found
         component-with-class-must-not-exist \simple-option
 
     specify "setting disabled to true must hide the dropdown and block interactivity", ->
         container = document.create-element \div
-        select = render do 
-            create-element do 
+        select = render do
+            create-element do
                 select-class
                 options: []
             container
         click-to-open-select-control select
-        select = render do 
-            create-element do 
+        select = render do
+            create-element do
                 select-class
                 disabled: true
                 options: []
             container
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must work when passed null props and undefined children", ->
-        TestUtils.render-into-document do 
-            create-element do 
+        TestUtils.render-into-document do
+            create-element do
                 select-class
                 null
 
@@ -324,9 +324,9 @@ module.exports = (select-class) !->
         select = create-select!
         toggle-button = find-rendered-DOM-component-with-class select, \react-selectize-toggle-button
         mouse-down toggle-button
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
         mouse-down toggle-button
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must wrap around on hitting the boundary", ->
         select = create-select!
@@ -354,25 +354,25 @@ module.exports = (select-class) !->
         select = create-select!
         click-to-open-select-control select
         select.blur!
-        component-with-class-must-not-exist \dropdown-menu
+        component-with-class-must-not-exist \rs-dropdown-menu
 
     specify "pressing down arrow key on a closed select must open and select the first option", ->
         select = create-select!
         press-down-arrow get-input select
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
         assert \apple == get-item-text (find-rendered-DOM-component-with-class select, \highlight)
 
     specify "pressing up arrow key on a closed select must open and select the first option", ->
         select = create-select!
         press-up-arrow get-input select
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
         assert \apple == get-item-text (find-rendered-DOM-component-with-class select, \highlight)
 
     specify "must not interfere with command + enter or control + enter", ->
         select = create-select!
         click-to-open-select-control select
         key-down (get-input select), which: 13, meta-key: true
-        find-rendered-DOM-component-with-class select, \dropdown-menu
+        find-rendered-DOM-component-with-class select, \rs-dropdown-menu
 
     specify "hide reset button when nothing is selected", ->
         select = create-select!
@@ -385,14 +385,14 @@ module.exports = (select-class) !->
         find-rendered-DOM-component-with-class select, \react-selectize-reset-button-container
 
     specify "props.hideResetButton must hide reset button", ->
-        select = create-select do 
+        select = create-select do
             hide-reset-button: true
         click-to-open-select-control select
         click-option find-highlighted-option select
         component-with-class-must-not-exist select, \react-selectize-reset-button-container
 
     specify "must pass props.inputProps to search field", ->
-        select = create-select do 
+        select = create-select do
             input-props: disabled: true
         input = get-input select
         assert input.disabled == true

--- a/test/multi-select.ls
+++ b/test/multi-select.ls
@@ -11,19 +11,19 @@ ReactSelectize = require \../src/index.ls
 # TestUtils
 {
     find-rendered-DOM-component-with-class
-    scry-rendered-DOM-components-with-class, 
+    scry-rendered-DOM-components-with-class,
     find-rendered-DOM-component-with-tag
     Simulate:{change, click, focus, key-down, paste}
 }:TestUtils = require \react-dom/test-utils
 
 # utils
-{create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, 
-find-highlighted-option, component-with-class-must-not-exist, press-backspace, press-escape, press-tab, 
-press-return, press-up-arrow, press-down-arrow, press-left-arrow, press-right-arrow, press-command-left, 
+{create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control,
+find-highlighted-option, component-with-class-must-not-exist, press-backspace, press-escape, press-tab,
+press-return, press-up-arrow, press-down-arrow, press-left-arrow, press-right-arrow, press-command-left,
 press-command-right} = require \./utils
 
 describe "MultiSelect", ->
-    
+
     # create-multi-select :: Props -> [ReactElement] -> MultiSelect
     create-multi-select = (props = {}, children = []) ->
         create-select ReactSelectize.MultiSelect, props, children
@@ -40,8 +40,8 @@ describe "MultiSelect", ->
         assert.equal select.values!.0.label, \mango
 
     specify "must use values from props instead of state when available", ->
-        select  = create-multi-select do 
-            values: 
+        select  = create-multi-select do
+            values:
                 * label: \apple, value: \apple
                 * label: \mango, value: \mango
                 ...
@@ -51,7 +51,7 @@ describe "MultiSelect", ->
         assert.equal select.values!.length, 2
 
     specify "must invoke on-values-change when the value (state) is changed", (done) ->
-        select = create-multi-select do 
+        select = create-multi-select do
             on-values-change: (values) ~>
                 assert.equal values.length, 1
                 assert.equal values.0.label, \apple
@@ -60,8 +60,8 @@ describe "MultiSelect", ->
         click-option find-highlighted-option select
 
     specify "must invoke on-value-change when the value (prop) is changed", (done) ->
-        select = create-multi-select do 
-            values: 
+        select = create-multi-select do
+            values:
                 * label: \apple, value: \apple
                 ...
             on-values-change: (values) ~>
@@ -73,12 +73,12 @@ describe "MultiSelect", ->
         click-option find-highlighted-option select
 
     specify "must use anchor from props instead of state when available", ->
-        select  = create-multi-select do 
+        select  = create-multi-select do
             anchor: undefined
         click-to-open-select-control select
         [0 til 4] |> each ~> click-option find-highlighted-option select
-        assert.equal do 
-            select.values! 
+        assert.equal do
+            select.values!
                 |> map (.label)
                 |> Str.join \,
             "grapes,orange,mango,apple"
@@ -86,7 +86,7 @@ describe "MultiSelect", ->
     specify "must invoke on-anchor-change on pressing left/right arrow keys", (done) ->
         left-count = 0
         right-count = 0
-        select  = create-multi-select do 
+        select  = create-multi-select do
             on-anchor-change: (anchor) ->
                 if anchor?.label == \orange
                     left-count := left-count + 1
@@ -108,19 +108,19 @@ describe "MultiSelect", ->
         assert select.values!.length, 2
 
     specify "@props.max-values must restrict the maximum selectable values", ->
-        select = create-multi-select do 
+        select = create-multi-select do
             max-values: 2
         click-to-open-select-control select
         click-option find-highlighted-option select
         click-option find-highlighted-option select
-        assert component-with-class-must-not-exist select, \dropdown-menu
+        assert component-with-class-must-not-exist select, \rs-dropdown-menu
         click-to-open-select-control select
-        assert component-with-class-must-not-exist select, \dropdown-menu
+        assert component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "command + left/right must position the cursor at the start/end", (done) ->
         start-count = 0
         end-count = 0
-        select = create-multi-select do 
+        select = create-multi-select do
             on-anchor-change: (anchor) ->
                 if anchor == undefined
                     start-count := start-count + 1
@@ -138,14 +138,14 @@ describe "MultiSelect", ->
         select = create-multi-select!
         click-to-open-select-control select
         [0 til 8] |> each ~> click-option find-highlighted-option select
-        component-with-class-must-not-exist select, \dropdown-menu
+        component-with-class-must-not-exist select, \rs-dropdown-menu
 
     specify "must be able to select other values when props.default-values is defined", ->
-        select = create-multi-select do 
+        select = create-multi-select do
             default-values:
-                * label: \apple 
-                  value: \apple 
-                * label: \mango 
+                * label: \apple
+                  value: \apple
+                * label: \mango
                   value: \mango
                 ...
         click-to-open-select-control select
@@ -155,7 +155,7 @@ describe "MultiSelect", ->
         assert.equal select.values!.length, 3
 
     specify "case senstivity", ->
-        select = create-multi-select do 
+        select = create-multi-select do
             options:
                 * label: \apple
                   value: \1
@@ -167,7 +167,7 @@ describe "MultiSelect", ->
         find-rendered-DOM-component-with-class select, \simple-option
 
     specify "must create values from pasted text & override the on-paste prop", ->
-        select = create-multi-select do 
+        select = create-multi-select do
             values-from-paste: (, , search) ~> search.split \, |> map ~> label: it, value: it
             on-paste: (e) ~> true
         click-to-open-select-control
@@ -176,12 +176,12 @@ describe "MultiSelect", ->
         assert select.values!.length == 3
 
     specify "option groups", ->
-        select = create-multi-select do 
-            groups: 
+        select = create-multi-select do
+            groups:
                 * group-id: 1
                   title: \A
                 * group-id :2
-                  title: \B 
+                  title: \B
                 ...
             options:
                 * label: \11

--- a/test/simple-select.ls
+++ b/test/simple-select.ls
@@ -19,12 +19,12 @@ create-react-class = require \create-react-class
 }:TestUtils = require \react-dom/test-utils
 
 # utils
-{create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, find-highlighted-option, 
-component-with-class-must-not-exist, press-backspace, press-escape, press-tab, press-return, press-up-arrow, press-down-arrow, 
+{create-select, get-input, set-input-text, get-item-text, click-option, click-to-open-select-control, find-highlighted-option,
+component-with-class-must-not-exist, press-backspace, press-escape, press-tab, press-return, press-up-arrow, press-down-arrow,
 press-left-arrow, press-right-arrow, press-command-left, press-command-right} = require \./utils
 
 describe "SimpleSelect", ->
-    
+
     common-tests ReactSelectize.SimpleSelect
 
     # create-simple-select :: Props -> [ReactElement] -> SimpleSelect
@@ -40,7 +40,7 @@ describe "SimpleSelect", ->
         assert.equal select.value!.label, \mango
 
     specify "must use value from props instead of state when available", ->
-        select  = create-simple-select do 
+        select  = create-simple-select do
             value: label: \apple, value: \apple
         click-to-open-select-control select
         [0 til 3] |> each -> press-down-arrow (get-input select)
@@ -48,15 +48,15 @@ describe "SimpleSelect", ->
         assert.equal select.value!.label, \apple
 
     specify "must invoke on-value-change when the value (state) is changed", (done) ->
-        select = create-simple-select do 
+        select = create-simple-select do
             on-value-change: (value) ~>
                 assert.equal value.label, \apple
                 done!
         click-to-open-select-control select
         click-option find-highlighted-option select
-        
+
     specify "must invoke on-value-change when the value (prop) is changed", (done) ->
-        select = create-simple-select do 
+        select = create-simple-select do
             value: label: \apple, value: \apple
             on-value-change: (value) ~>
                 assert.equal value.label, \mango
@@ -75,8 +75,8 @@ describe "SimpleSelect", ->
 
     specify "selecting the same value must have no effect", ->
         called = 0
-        select = create-simple-select do 
-            on-value-change: ~> 
+        select = create-simple-select do
+            on-value-change: ~>
                 called := called + 1
         click-to-open-select-control select
         set-input-text (get-input select), \e
@@ -106,16 +106,16 @@ describe "SimpleSelect", ->
     specify "must be able to block default backspace action", ->
         {refs:{select}} = TestUtils.render-into-document create-element create-react-class do
             render: ->
-                create-element do 
+                create-element do
                     ReactSelectize.SimpleSelect
                     ref: \select
-                    value: @state.value 
-                    options: 
+                    value: @state.value
+                    options:
                         * label: \apple, value: \apple
                         * label: \banana, value: \banana
                         * label: \mango, value: \mango
                     on-value-change: (value) ~>
-                        if !!value 
+                        if !!value
                             @set-state {value}
             get-initial-state: -> value: undefined
         click-to-open-select-control select
@@ -125,7 +125,7 @@ describe "SimpleSelect", ->
         find-rendered-DOM-component-with-class select, \simple-value
 
     specify "selected value must be displayed as search text when props.editable is true ", ->
-        select = create-simple-select do 
+        select = create-simple-select do
             editable: (.label)
         click-to-open-select-control select
         click-option find-highlighted-option select
@@ -134,7 +134,7 @@ describe "SimpleSelect", ->
         assert.equal (get-input select).value, \apple
 
     specify "must be able to select another value when props.default-value is defined", ->
-        select = create-simple-select do 
+        select = create-simple-select do
             default-value: label: \mango, value: \mango
         click-to-open-select-control select
         assert.equal select.value!.label. \mango
@@ -143,7 +143,7 @@ describe "SimpleSelect", ->
         assert.equal select.value!.label. \apple
 
     specify "form serialization", ->
-        select = create-simple-select do 
+        select = create-simple-select do
             name: \test
         click-to-open-select-control select
         click-option find-highlighted-option select
@@ -159,6 +159,6 @@ describe "SimpleSelect", ->
         set-input-text input, "some random text"
         press-return input
         <~ set-timeout _, 25
-        component-with-class-must-not-exist \dropdown-menu
+        component-with-class-must-not-exist \rs-dropdown-menu
         assert select.state.search == ""
         done!

--- a/themes/base.styl
+++ b/themes/base.styl
@@ -16,8 +16,8 @@ height = 30px
         display flex
         align-items flex-start
         position relative
-        
-        // this controls the height of the select 
+
+        // this controls the height of the select
         padding 2px
 
         .react-selectize-placeholder
@@ -39,7 +39,7 @@ height = 30px
             .resizable-input
                 background none
                 border none
-                outline none 
+                outline none
                 font-size 1em
                 margin 2px
                 padding 4px 0px
@@ -61,13 +61,13 @@ height = 30px
 
         .react-selectize-reset-button-container
             width 16px
-        
+
         .react-selectize-toggle-button-container
             width 32px
 
         .react-selectize-reset-button-container:hover .react-selectize-reset-button path
             stroke #c0392b
-        
+
         .react-selectize-reset-button path
             transition stroke 0.5s 0s ease
             stroke #999
@@ -89,7 +89,7 @@ height = 30px
         width 100%
 
 // dropdown-menu present in document.body when props.tether is true
-.react-selectize.dropdown-menu
+.react-selectize.rs-dropdown-menu
     box-sizing border-box
     overflow auto
     position absolute
@@ -113,7 +113,7 @@ height = 30px
 
 // MULTI SELECT
 .multi-select.react-selectize.root-node
-    
+
     .simple-value
         display inline-block
         margin 2px
@@ -126,7 +126,7 @@ height = 30px
 
 // SIMPLE SELECT
 .simple-select.react-selectize.root-node
-    
+
     .simple-value
         margin 2px
 

--- a/themes/bootstrap3.styl
+++ b/themes/bootstrap3.styl
@@ -32,18 +32,18 @@
 
     &:not(.flipped)
         margin-top 5px
-    
-    .dropdown-menu
-        
+
+    .rs-dropdown-menu
+
         &.custom-enter-active, &.custom-leave-active
             transition opacity 0.2s 0s ease
 
         &.custom-enter
             opacity 0
-        
+
         &.custom-enter-active
             opacity 1
-        
+
         &.custom-leave
             opacity 1
 
@@ -51,7 +51,7 @@
             opacity 0
 
 // dropdown-menu present in document.body when props.tether is true
-.react-selectize.bootstrap3.dropdown-menu
+.react-selectize.bootstrap3.rs-dropdown-menu
     background white
     border 1px solid #ccc
     border-radius 4px

--- a/themes/default.styl
+++ b/themes/default.styl
@@ -4,7 +4,7 @@
     font-family Helvetica Neue, Helvetica, Arial, sans-serif
 
 .react-selectize.default.root-node
-    
+
     .react-selectize-control
         background-color white
         border 1px solid
@@ -18,7 +18,7 @@
 
         .react-selectize-search-field-and-selected-values
             padding-left 5px
-    
+
     &.open
 
         &.flipped
@@ -30,7 +30,7 @@
                 border-top-right-radius 0px
 
         &:not(.flipped)
-            
+
             .react-selectize-control
                 border-bottom-left-radius 0px
                 border-bottom-right-radius 0px
@@ -42,19 +42,19 @@
 .react-selectize.dropdown-menu-wrapper.default
     overflow hidden
 
-    .dropdown-menu
-        
+    .rs-dropdown-menu
+
         &.custom-enter-active, &.custom-leave-active
             transition transform 0.2s 0s ease
 
         &.flipped
-        
+
             &.custom-enter
                 transform translateY(100%)
-            
+
             &.custom-enter-active
                 transform translateY(0%)
-            
+
             &.custom-leave
                 transform translateY(0%)
 
@@ -65,10 +65,10 @@
 
             &.custom-enter
                 transform translateY(-100%)
-            
+
             &.custom-enter-active
                 transform translateY(0%)
-            
+
             &.custom-leave
                 transform translateY(0%)
 
@@ -76,7 +76,7 @@
                 transform translateY(-100%)
 
 // dropdown-menu present in document.body when props.tether is true
-.react-selectize.dropdown-menu.default
+.react-selectize.rs-dropdown-menu.default
     background white
     border 1px solid #ccc
     margin-top -1px
@@ -89,7 +89,7 @@
         border-color #b3b3b3 #cccccc #d9d9d9
         border-bottom-left-radius 4px
         border-bottom-right-radius 4px
-    
+
 
     .no-results-found
         color #aaa !important
@@ -101,7 +101,7 @@
         padding 8px 8px
 
     .option-wrapper
-        
+
         &.highlight
             background #f2f9fc
             color #333
@@ -128,10 +128,10 @@
 
 // SIMPLE SELECT
 .simple-select.react-selectize.default.root-node
-    
+
     &.open .react-selectize-control
         background-color white
-    
+
     &:not(.open) .react-selectize-control
         background-color #f9f9f9
         background-image linear-gradient(to bottom, #fefefe, #f2f2f2)

--- a/themes/material.styl
+++ b/themes/material.styl
@@ -4,11 +4,11 @@
     font-family Roboto, sans-serif
 
 .react-selectize.material.root-node
-    
+
     &.open .react-selectize-control:after
         transform scaleX(1)
 
-    .react-selectize-control 
+    .react-selectize-control
         border-bottom 1px solid rgba(0, 0, 0, 0.3)
 
         &:after
@@ -32,16 +32,16 @@
     &.flipped
         margin-bottom 8px
 
-        .dropdown-menu
+        .rs-dropdown-menu
             transform-origin 100% 100%
 
     &:not(.flipped)
         margin-top 8px
 
-        .dropdown-menu
+        .rs-dropdown-menu
             transform-origin 0% 0%
 
-    .dropdown-menu
+    .rs-dropdown-menu
 
         &.custom-enter-active, &.custom-leave-active
             transition transform 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms
@@ -62,7 +62,7 @@
             opacity 0
 
 // dropdown-menu present in document.body when props.tether is true
-.react-selectize.material.dropdown-menu
+.react-selectize.material.rs-dropdown-menu
     background-color white
     border-radius 2px
     box-shadow rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px
@@ -74,7 +74,7 @@
 
     &:not(.flipped)
         margin-top 8px
-    
+
     .no-results-found
         font-style oblique
         font-size 16px


### PR DESCRIPTION
This is the updated PR for #143, I updated to resolve merge conflicts. View at https://github.com/furqanZafar/react-selectize/pull/187/files?w=1 to ignore whitespace changes.

Original description below:

---

I ran into some issues with using the following properties:

* tether
* dropdown-direction

when using react-selectize within an application with bootstrap3 css included. 

The issue seems to be a clash between bootstrap and react-selectize over the `.dropdown-menu` class name. I renamed `dropdown-menu` to `rs-dropdown-menu` as a sanity check, and it fixed the issues I was having. 

I don't think this current PR is a great solution as it would break any existing customized css people have made for the dropdown menu, but this was the quickest fix for my purposes.

@furqanZafar I'd appreciate your input as to what you think is the best way to solve this.

See https://github.com/furqanZafar/react-selectize/issues/137 for more details.